### PR TITLE
Fix LLM cleanup safety

### DIFF
--- a/app/core.py
+++ b/app/core.py
@@ -93,4 +93,5 @@ class Core:
             print('\a')
 
     def cleanup(self):
-        self.llm.cleanup()
+        if self.llm:
+            self.llm.cleanup()


### PR DESCRIPTION
## Summary
- avoid AttributeError if LLM fails to initialize by checking for `self.llm`

## Testing
- `pytest -q` *(fails: KeyError: 'DISPLAY')*
- `pip install -r requirements.txt` *(fails: Failed to build PyAudio)*

------
https://chatgpt.com/codex/tasks/task_e_6853130317b4832a831e159a80caec87