### PR TITLE
Add Claude test using mocked Anthropics

### DIFF
--- a/app/models/claude.py
+++ b/app/models/claude.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any
+from anthropic import Anthropic
+from .model import Model
+from ..utils.screen import Screen
+
+
+class Claude(Model):
+    def __init__(self, model_name, api_key, context):
+        super().__init__(model_name, base_url="https://api.anthropic.com/v1/", api_key=api_key, context=context)
+        # Anthropic client doesn't take base_url in this simple wrapper but our
+        # Model base class expects one. We'll ignore base_url argument by
+        # overriding client with Anthropic.
+        self.client = Anthropic(api_key=api_key)
+
+    def get_instructions_for_objective(self, original_user_request: str, step_num: int = 0) -> dict[str, Any]:
+        data = self.format_user_request_for_llm(original_user_request, step_num)
+        llm_response = self.client.messages.create(**data)
+        return self.convert_llm_response_to_json_instructions(llm_response)
+
+    def format_user_request_for_llm(self, original_user_request: str, step_num: int) -> dict[str, Any]:
+        base64_img = Screen().get_screenshot_in_base64()
+        request_data = json.dumps({
+            "original_user_request": original_user_request,
+            "step_num": step_num
+        })
+        messages = [
+            {
+                "role": "user",
+                "content": self.context + request_data
+            },
+            {
+                "role": "user",
+                "content": {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": base64_img
+                    }
+                }
+            }
+        ]
+        return {
+            "model": self.model_name,
+            "messages": messages,
+            "max_tokens": 800
+        }
+
+    def convert_llm_response_to_json_instructions(self, llm_response: Any) -> dict[str, Any]:
+        llm_response_data = llm_response["content"][0]["text"].strip()
+        start_index = llm_response_data.find("{")
+        end_index = llm_response_data.rfind("}")
+        try:
+            json_response = json.loads(llm_response_data[start_index:end_index + 1].strip())
+        except Exception as e:
+            print(f"Error while parsing JSON response - {e}")
+            json_response = {}
+        return json_response
+
+    def cleanup(self):
+        pass

--- a/app/utils/screen.py
+++ b/app/utils/screen.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pyautogui
 from PIL import Image
-from utils.settings import Settings
+from .settings import Settings
 
 
 class Screen:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Add project root to sys.path so test modules can import the app package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+# Provide a stub for pyautogui so importing Screen doesn't fail
+sys.modules.setdefault('pyautogui', ModuleType('pyautogui'))
+pil = ModuleType('PIL')
+image_mod = ModuleType('PIL.Image')
+image_mod.Image = type('Image', (), {})
+pil.Image = image_mod
+sys.modules.setdefault('PIL', pil)
+sys.modules.setdefault('PIL.Image', image_mod)
+
+# Ensure app package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.models.claude import Claude
+
+
+def test_get_instructions_for_objective_parses_response():
+    mock_response = {"content": [{"text": '{"steps": [], "done": "ok"}' }]}
+
+    with patch('anthropic.resources.messages.messages.Messages.create', return_value=mock_response) as mock_create, \
+         patch('app.models.claude.Screen.get_screenshot_in_base64', return_value='imgdata'):
+        claude = Claude(model_name='claude-3', api_key='test', context='')
+        result = claude.get_instructions_for_objective('do something', 0)
+
+        assert result == {"steps": [], "done": "ok"}
+        mock_create.assert_called_once()


### PR DESCRIPTION
## Summary
- add a minimal Claude model using Anthropic client
- adjust Screen for package-relative Settings import
- set up path handling in tests package
- provide a Claude unit test with mocks for Anthropics

## Testing
- `PYENV_VERSION=3.12.10 pytest tests/test_claude.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853043e5cc4832a81580d157f5cd372